### PR TITLE
optimizing browserify options

### DIFF
--- a/generators/app/templates/gruntfile-config.json
+++ b/generators/app/templates/gruntfile-config.json
@@ -28,25 +28,11 @@
         "options": {
           "browserifyOptions": {
             "standalone": "index",
+            "node":true,
             "commondir": false,
-            "builtins": [
-              "stream",
-              "util",
-              "path",
-              "url",
-              "string_decoder",
-              "events",
-              "net",
-              "punycode",
-              "querystring",
-              "dgram",
-              "dns",
-              "assert",
-              "tls",
-              "crypto"
-            ],
-            "insertGlobals": false,
-            "detectGlobals": false
+            "browserField": false,
+            "builtins": false,
+            "insertGlobals": false
           }
         }
       }


### PR DESCRIPTION
all builtins have been moved into mozu arc js core so removing them from the build.
setting browserField to false to avoid the alternative modules that expect browser globals.