### PR TITLE
Use the generated .jshintrc in apps by default.

### DIFF
--- a/generators/action/templates/_action_implementation.jst
+++ b/generators/action/templates/_action_implementation.jst
@@ -25,6 +25,7 @@
 <% } -%>
 
  */
+'use strict';
 
 module.exports = function(context, callback) {
   callback();

--- a/generators/action/templates/_manifest.jst
+++ b/generators/action/templates/_manifest.jst
@@ -1,3 +1,4 @@
+'use strict';
 module.exports = {
 <% actions.forEach(function(action, i) { -%>
   <% action.customFunctionNames.forEach(function(customFunctionName, j) { %>

--- a/generators/app/templates/gruntfile-config.json
+++ b/generators/app/templates/gruntfile-config.json
@@ -1,6 +1,7 @@
 {
   "configs": {
     "jshint": {
+      "options": "./.jshintrc",
       "normal": [
         "./assets/src/**/*.js"
       ],


### PR DESCRIPTION
When I started adding `'use strict';` to my actions, the jshint task gave an error telling me to use the function form of 'use strict'. After discovering that error is turned off for the "node" setting in jshint, I also found that it was already set to `true` in .jshintrc.

Turns out that the Grunt task for JSHint doesn't give any options at all by default. Since this generator creates .jshintrc, let's actually use it.

Furthermore, "strict" is set to `true` in that file as well, but not every JS file created by the generator used 'use strict'. This has been changed as well.